### PR TITLE
Update Exercises_1.ipynb

### DIFF
--- a/Exercises_1.ipynb
+++ b/Exercises_1.ipynb
@@ -1040,7 +1040,7 @@
    },
    "outputs": [],
    "source": [
-    "sales.loc[(sales['Customer_Gender'] == 'M') & (sales['Revenue'] == 500)].shape[0]"
+    "sales.loc[(sales['Customer_Gender'] == 'M') & (sales['Revenue'] > 500)].shape[0]"
    ]
   },
   {


### PR DESCRIPTION
Before, the task "How many sales with more than 500 in `Revenue` were made by men?" returns the ammount of men who spent exactly 500, not more than 500.